### PR TITLE
joyent/node-mahi#7 exact-match target rules can be missed in mahi.authorize()

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2022 The University of Queensland
  */
 
 var assert = require('assert-plus');
@@ -523,10 +524,22 @@ MahiClient.prototype.authorize = function authorize(opts) {
                 return (true);
             if (typeof (rule[1].resources) !== 'object')
                 return (false);
+            /*
+             * Two ways for an exact match to be formatted: as an array, or as
+             * a lookup object.
+             */
             if (Array.isArray(rule[1].resources.exact)) {
                 if (rule[1].resources.exact.length > 0)
                     return (true);
+            } else if (typeof (rule[1].resources.exact) === 'object' &&
+                rule[1].resources.exact !== null) {
+
+                if (Object.keys(rule[1].resources.exact).length > 0)
+                    return (true);
             }
+            /*
+             * Regexes are always an array.
+             */
             if (Array.isArray(rule[1].resources.regex)) {
                 if (rule[1].resources.regex.length > 0)
                     return (true);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "mahi",
     "description": "Mahi client",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "author": "Joyent (joyent.com)",
     "main": "index.js",
     "dependencies": {


### PR DESCRIPTION
See issue for explanation. Tested this by hot-patching into muskie -- resolves issues our users were having with these rules.