### PR TITLE
MANTA-5475 Allow the use of Access keys to move towards AWS Signature V4 for manta-buckets requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!--
     Copyright (c) 2014, Joyent, Inc.
-    Copyright 2022 MNX Cloud, Inc.
+    Copyright 2025 Edgecast Cloud LLC.
 -->
 
 # node-mahi
@@ -18,6 +18,49 @@ guidelines, issues, and general documentation, visit the main
 This is the client for Mahi. When talking to mahi, translation and
 authentication responses are cached. node-mahi also contains the authorization
 API.
+
+## Authentication Methods
+
+node-mahi supports two authentication methods:
+
+### SSH Key Authentication (Traditional)
+- `verifySignature(opts, cb)` - Verifies SSH key signatures
+
+### AWS SigV4 Authentication (S3 API Compatibility)
+- `getUserByAccessKey(accessKeyId, cb)` - Look up user by access key ID
+- `verifySigV4(request, cb)` - Verify AWS Signature Version 4 authentication
+
+## AWS S3 API Integration
+
+For S3 API compatibility, use the SigV4 authentication methods:
+
+```javascript
+var mahi = require('node-mahi').createClient({
+    url: 'http://mahi.example.com'
+});
+
+// Look up user by access key (for S3 gateway integration)
+mahi.getUserByAccessKey('AKIA123456789EXAMPLE', function(err, user) {
+    if (err) {
+        console.error('Access key lookup failed:', err);
+        return;
+    }
+    console.log('User:', user.login);
+});
+
+// Verify SigV4 signature
+mahi.verifySigV4(httpRequest, function(err, result) {
+    if (err) {
+        console.error('SigV4 verification failed:', err);
+        return;
+    }
+    console.log('Authentication successful:', result.accessKeyId);
+});
+```
+
+### S3 Client Compatibility
+
+TBD
 
 # Testing
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,6 +7,7 @@
 /*
  * Copyright 2020 Joyent, Inc.
  * Copyright 2022 The University of Queensland
+ * Copyright 2025 Edgecast Cloud LLC.
  */
 
 var assert = require('assert-plus');
@@ -789,6 +790,91 @@ MahiClient.prototype.getLookup = function getLookup(opts, cb) {
     });
 };
 
+
+/**
+ * Look up user by access key ID
+ * Used for S3 gateway integration - resolves access keys to user accounts
+ *
+ * accessKeyId: AWS access key ID (e.g., "AKIA123456789EXAMPLE")
+ * cb: callback in the form fn(err, userInfo)
+ * 
+ * Returns user object without access key secrets:
+ * {
+ *     type: "account",
+ *     uuid: "user-uuid",
+ *     login: "username",
+ *     accesskeys: ["AKIA123456789EXAMPLE"],
+ *     approved_for_provisioning: true
+ * }
+ *
+ * errors:
+ * AccessKeyNotFoundError
+ * RedisError
+ */
+MahiClient.prototype.getUserByAccessKey = function 
+    getUserByAccessKey(accessKeyId, cb) {
+        assert.string(accessKeyId, 'accessKeyId');
+        assert.func(cb, 'callback');
+    
+        var self = this;
+        var path = sprintf('/aws-auth/%s', accessKeyId);
+        
+        self.http.get(path, function (err, req, res, obj) {
+            if (err) {
+                cb(err);
+                return;
+            }
+            cb(null, obj);
+        });
+};
+
+
+/**
+ * Verify AWS Signature Version 4 authentication
+ * 
+ * request: HTTP request object with AWS4-HMAC-SHA256 authorization header
+ * cb: callback in the form fn(err, result)
+ *
+ * Returns:
+ * {
+ *     valid: true,
+ *     accessKeyId: "AKIA123456789EXAMPLE", 
+ *     userUuid: "user-uuid"
+ * }
+ *
+ * errors:
+ * InvalidSignatureError
+ * AccessKeyNotFoundError  
+ * RequestTimeTooSkewedError
+ */
+MahiClient.prototype.verifySigV4 = function verifySigV4(request, cb) {
+    assert.object(request, 'request');
+    assert.func(cb, 'callback');
+
+    var self = this;
+    
+    // Forward the original headers to mahi for SigV4 verification
+    var requestOptions = {
+        path: '/aws-verify',
+        headers: request.headers
+    };
+    
+    // Add request method and URL as query parameters since mahi needs them for verification
+    var qs = require('querystring');
+    var queryParams = {
+        method: request.method,
+        url: request.url
+    };
+    requestOptions.path += '?' + qs.stringify(queryParams);
+    
+    self.http.post(requestOptions, {}, function (err, req, res, obj) {
+        if (err) {
+            cb(err);
+            return;
+        }
+        cb(null, obj);
+    });
+};
 
 
 module.exports = {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright (c) 2014, Joyent, Inc.
+ * Copyright 2025 Edgecast Cloud LLC.
  */
 
 var util = require('util');
@@ -19,6 +20,17 @@ function MahiError(obj) {
 }
 util.inherits(MahiError, RestError);
 MahiError.prototype.name = 'MahiError';
+
+function AccessKeyNotFoundError(accessKeyId) {
+    MahiError.call(this, {
+        restCode: 'AccessKeyNotFound',
+        statusCode: 404,
+        message: 'Access key ' + accessKeyId + ' does not exist'
+    });
+}
+util.inherits(AccessKeyNotFoundError, MahiError);
+AccessKeyNotFoundError.prototype.name = 'AccessKeyNotFoundError';
+
 
 function AccountBlockedError(account) {
     MahiError.call(this, {
@@ -99,7 +111,20 @@ util.inherits(RulesEvaluationFailedError, MahiError);
 RulesEvaluationFailedError.prototype.name = 'RulesEvaluationFailedError';
 
 
+function RequestTimeTooSkewedError() {
+    MahiError.call(this, {
+        restCode: 'RequestTimeTooSkewed',
+        statusCode: 403,
+        message: 'The difference between the request time and the server' +
+        'time is too large'
+    });
+}
+util.inherits(RequestTimeTooSkewedError, MahiError);
+RequestTimeTooSkewedError.prototype.name = 'RequestTimeTooSkewedError';
+
+
 module.exports = {
+    AccessKeyNotFoundError: AccessKeyNotFoundError,
     AccountBlockedError: AccountBlockedError,
     CrossAccountError: CrossAccountError,
     InvalidRoleError: InvalidRoleError,
@@ -107,5 +132,6 @@ module.exports = {
     KeyDoesNotExistError: KeyDoesNotExistError,
     MahiError: MahiError,
     NoMatchingRoleTagError: NoMatchingRoleTagError,
+    RequestTimeTooSkewedError: RequestTimeTooSkewedError,
     RulesEvaluationFailedError: RulesEvaluationFailedError
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "mahi",
     "description": "Mahi client",
-    "version": "2.4.4",
+    "version": "2.5.0",
     "author":"Edgecast Cloud (edgecast.io)",
     "main": "index.js",
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "mahi",
     "description": "Mahi client",
-    "version": "2.4.3",
-    "author": "MNX Cloud (mnx.io)",
+    "version": "2.4.4",
+    "author":"Edgecast Cloud (edgecast.io)"
     "main": "index.js",
     "dependencies": {
         "aperture": "git+https://github.com/TritonDataCenter/node-aperture.git#3081d76351d44c7ab1f3d7966b6636c4053b80f8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mahi",
     "description": "Mahi client",
     "version": "2.4.4",
-    "author":"Edgecast Cloud (edgecast.io)"
+    "author":"Edgecast Cloud (edgecast.io)",
     "main": "index.js",
     "dependencies": {
         "aperture": "git+https://github.com/TritonDataCenter/node-aperture.git#3081d76351d44c7ab1f3d7966b6636c4053b80f8",


### PR DESCRIPTION
This change allows the use of access keys for authentication via SigV4. The only service that will use this new method is
manta-buckets-api (MANTA-5471 branch).

This change contains the following tickets:

MANTA-5471
MANTA-5476
MANTA-5477
MANTA-5478
MANTA-5479